### PR TITLE
Fix tls

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -13,7 +13,7 @@ spec:
   tls:
   - hosts:
     - "{{ .Values.ingress.host }}"
-    secretName: tls-bundle-build #{{ template "fullname" . }}-tls
+    secretName: {{ template "fullname" . }}-tls
 {{- end }}
   rules:
   - host: '{{ .Values.ingress.host }}'

--- a/templates/nginx-configmap.yaml
+++ b/templates/nginx-configmap.yaml
@@ -15,14 +15,18 @@ data:
     server {
             listen 80 default_server;
             listen [::]:80 default_server ipv6only=on;
-            
+
             root /usr/share/nginx/html;
             index index.html index.htm;
             server_name {{ .Values.ingress.host }};
 
             location / {
               proxy_set_header X-Forwarded-For $remote_addr;
-              proxy_set_header X-Forwarded-Proto https;
+              {{- if .Values.ingress.ssl.enabled }}
+                proxy_set_header X-Forwarded-Proto https;
+              {{- else }}
+                proxy_set_header X-Forwarded-Proto http;
+              {{- end }}
               proxy_set_header Host $http_host;
 
               proxy_pass http://127.0.0.1:8000;
@@ -40,10 +44,14 @@ data:
               proxy_set_header Connection "upgrade";
               proxy_read_timeout 86400;
               proxy_set_header X-Forwarded-For $remote_addr;
-              proxy_set_header X-Forwarded-Proto https;
+              {{- if .Values.ingress.ssl.enabled }}
+                proxy_set_header X-Forwarded-Proto https;
+              {{- else }}
+                proxy_set_header X-Forwarded-Proto http;
+              {{- end }}
               proxy_set_header Host $http_host;
           }
       }
 
-    
+
 

--- a/templates/ssl-secrets.yaml
+++ b/templates/ssl-secrets.yaml
@@ -10,8 +10,8 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: kubernetes.io/tls
 data:
-  tls.crt: {{ .Values.tls.crt | b64enc }}
-  tls.key: {{ .Values.tls.key | b64enc }}
+  tls.crt: {{ .Values.tls.crt }}
+  tls.key: {{ .Values.tls.key  }}
 
 {{- end }}
 


### PR DESCRIPTION
Thanks for this chart! I had to do a few things to get this working:

- The ingress referred to a non-existent secret
- Provide TLS certs as base64 encoded prior to passing to helm
- Update nginx config to redirect to HTTPS only if TLS is enabled